### PR TITLE
Fixed #116 -- Added connection option SOCKET_CONNECT_TIMEOUT.

### DIFF
--- a/django_redis/pool.py
+++ b/django_redis/pool.py
@@ -74,6 +74,12 @@ class ConnectionFactory(object):
                 "Socket timeout should be float or integer"
             kwargs["socket_timeout"] = socket_timeout
 
+        socket_connect_timeout = self.options.get("SOCKET_CONNECT_TIMEOUT", None)
+        if socket_connect_timeout:
+            assert isinstance(socket_connect_timeout, (int, float)), \
+                "Socket connect timeout should be float or integer"
+            kwargs["socket_connect_timeout"] = socket_connect_timeout
+
         return kwargs
 
     def connect(self, url):

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -159,7 +159,8 @@ CACHES = {
 Socket timeout
 ~~~~~~~~~~~~~~
 
-Socket timeout can be set using `SOCKET_TIMEOUT` option:
+Socket timeout can be set using `SOCKET_TIMEOUT` and `SOCKET_CONNECT_TIMEOUT`
+options:
 
 [source, python]
 ----
@@ -167,11 +168,16 @@ CACHES = {
     "default": {
         # ...
         "OPTIONS": {
+            "SOCKET_CONNECT_TIMEOUT": 5,  # in seconds
             "SOCKET_TIMEOUT": 5,  # in seconds
         }
     }
 }
 ----
+
+`SOCKET_CONNECT_TIMEOUT` is the timeout for the connection to be established and
+`SOCKET_TIMEOUT` is the timeout for read and write operations after the connection
+is established.
 
 
 Compression support


### PR DESCRIPTION
The documentation was based on reading the code of redis-py, [this line](https://github.com/andymccurdy/redis-py/commit/465e74dce8c30263f48f522a1def89e0a4b20d00#diff-b3be2d0fa4e0cf1f1c403f2de43ecdb4R443) and [this line](https://github.com/andymccurdy/redis-py/commit/465e74dce8c30263f48f522a1def89e0a4b20d00#diff-b3be2d0fa4e0cf1f1c403f2de43ecdb4R449).

