### PR TITLE
Django 1.8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - DJANGO="django==1.6.3"
   - DJANGO="django==1.5.7"
   - DJANGO="django==1.4.12"
+  - DJANGO="django==1.8b1"
 
 matrix:
   exclude:

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -15,6 +15,7 @@ import random
 import socket
 import warnings
 import zlib
+from collections import OrderedDict
 
 try:
     from django.utils.encoding import smart_bytes
@@ -26,7 +27,6 @@ except ImportError:
 from django.conf import settings
 from django.core.cache.backends.base import get_key_func
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.datastructures import SortedDict
 
 try:
     from django.core.cache.backends.base import DEFAULT_TIMEOUT
@@ -323,7 +323,7 @@ class DefaultClient(object):
         if not keys:
             return {}
 
-        recovered_data = SortedDict()
+        recovered_data = OrderedDict()
 
         new_keys = [self.make_key(k, version=version) for k in keys]
         map_keys = dict(zip(new_keys, keys))

--- a/django_redis/client/herd.py
+++ b/django_redis/client/herd.py
@@ -2,11 +2,11 @@
 
 import random
 import time
+from collections import OrderedDict
 
 from redis.exceptions import ConnectionError
 
 from django.conf import settings
-from django.utils.datastructures import SortedDict
 
 from .default import DEFAULT_TIMEOUT, DefaultClient
 from ..exceptions import ConnectionInterrupted
@@ -93,7 +93,7 @@ class HerdClient(DefaultClient):
         if not keys:
             return {}
 
-        recovered_data = SortedDict()
+        recovered_data = OrderedDict()
 
         new_keys = [self.make_key(key, version=version) for key in keys]
         map_keys = dict(zip(new_keys, keys))

--- a/django_redis/client/sharded.py
+++ b/django_redis/client/sharded.py
@@ -3,11 +3,11 @@
 from __future__ import absolute_import, unicode_literals
 
 import re
+from collections import OrderedDict
 
 from redis.exceptions import ConnectionError
 
 from django.conf import settings
-from django.utils.datastructures import SortedDict
 
 try:
     from django.utils.encoding import smart_text
@@ -73,7 +73,7 @@ class ShardClient(DefaultClient):
         if not keys:
             return {}
 
-        recovered_data = SortedDict()
+        recovered_data = OrderedDict()
 
         new_keys = [self.make_key(key, version=version) for key in keys]
         map_keys = dict(zip(new_keys, keys))

--- a/django_redis/util.py
+++ b/django_redis/util.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import, unicode_literals
 import sys
+from importlib import import_module
 
 try:
     from django.utils.encoding import smart_text
@@ -22,7 +23,6 @@ from redis.connection import UnixDomainSocketConnection, Connection
 from redis.connection import DefaultParser
 
 from collections import defaultdict
-from django.utils.importlib import import_module
 
 if sys.version_info[0] < 3:
     integer_types = (int, long,)

--- a/tests/redis_backend_testapp/tests.py
+++ b/tests/redis_backend_testapp/tests.py
@@ -512,7 +512,13 @@ class DjangoOmitExceptionsTests(TestCase):
 
 
 from django.contrib.sessions.backends.cache import SessionStore as CacheSession
-from django.contrib.sessions.tests import SessionTestsMixin
+
+try:
+    # SessionTestsMixin isn't available for import on django >= 1.8
+    from django.contrib.sessions.tests import SessionTestsMixin
+except ImportError:
+    class SessionTestsMixin(object): pass
+
 
 
 class SessionTests(SessionTestsMixin, TestCase):

--- a/tests/test_sqlite_sharding.py
+++ b/tests/test_sqlite_sharding.py
@@ -12,6 +12,8 @@
 # database backends as possible.  You may want to create a separate settings
 # file for each of the backends you test against.
 
+import django
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3'
@@ -55,7 +57,10 @@ CACHES = {
     },
 }
 
-TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'
+if django.VERSION[1] >= 8:
+    TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+else:
+    TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'
 
 INSTALLED_APPS = (
     'redis_backend_testapp',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = {py27,pypy}-django{14,15,16,17},
-          {py33,py34,pypy3}-django{15,16,17}
+envlist = {py27,pypy}-django{14,15,16,17,18},
+          {py33,py34,pypy3}-django{15,16,17,18}
 
 [testenv]
 commands =
@@ -13,5 +13,6 @@ deps =
     django15: Django>=1.5, <1.6
     django16: Django>=1.6, <1.7
     django17: Django>=1.7, <1.8
+    django18: Django==1.8b1
     mock==1.0.1
     redis==2.10.3


### PR DESCRIPTION
- [use collections.OrderedDict instead SortedDict](https://docs.djangoproject.com/en/dev/releases/1.7/#django-utils-datastructures-sorteddict)
- [use importlib instead django.utils.importlib](https://docs.djangoproject.com/en/dev/releases/1.7/#django-utils-dictconfig-django-utils-importlib)