### PR TITLE
future 1.9 compatibility in tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dist*
 .\#*
 .tox
 dump.rdb
+.idea

--- a/tests/redis_backend_testapp/tests.py
+++ b/tests/redis_backend_testapp/tests.py
@@ -12,7 +12,11 @@ except ImportError:
     from mock import patch
 
 from django.conf import settings
-from django.core.cache import cache, get_cache
+from django.core.cache import cache
+try:
+    from django.core.cache import caches as get_cache
+except ImportError:
+    from django.core.cache import get_cache
 from django.test import TestCase
 
 import django_redis.cache
@@ -32,6 +36,7 @@ else:
 
 def make_key(key, prefix, version):
     return "{}#{}#{}".format(prefix, version, key)
+
 
 def reverse_key(key):
     return key.split("#", 2)[2]
@@ -77,6 +82,7 @@ class DjangoRedisConnectionStrings(TestCase):
         self.assertEqual(res2["url"], self.constring5)
         self.assertEqual(res3["url"], self.constring6)
 
+
 class DjangoRedisCacheTestCustomKeyFunction(TestCase):
     def setUp(self):
         self.old_kf = settings.CACHES['default'].get('KEY_FUNCTION')
@@ -91,14 +97,14 @@ class DjangoRedisCacheTestCustomKeyFunction(TestCase):
             pass
 
     def test_custom_key_function(self):
-        for key in ["foo-aa","foo-ab", "foo-bb","foo-bc"]:
+        for key in ["foo-aa", "foo-ab", "foo-bb", "foo-bc"]:
             self.cache.set(key, "foo")
 
         res = self.cache.delete_pattern("*foo-a*")
         self.assertTrue(bool(res))
 
         keys = self.cache.keys("foo*")
-        self.assertEqual(set(keys), set(["foo-bb","foo-bc"]))
+        self.assertEqual(set(keys), set(["foo-bb", "foo-bc"]))
         # ensure our custom function was actually called
         try:
             self.assertEqual(set(k.decode('utf-8') for k in self.cache.raw_client.keys('*')),
@@ -412,7 +418,7 @@ class DjangoRedisCacheTests(TestCase):
         self.assertTrue(bool(res))
 
         keys = self.cache.keys("foo*")
-        self.assertEqual(set(keys), set(["foo-bb","foo-bc"]))
+        self.assertEqual(set(keys), set(["foo-bb", "foo-bc"]))
 
         res = self.cache.delete_pattern("*foo-a*")
         self.assertFalse(bool(res))
@@ -428,7 +434,7 @@ class DjangoRedisCacheTests(TestCase):
         _is_herd = (_params["OPTIONS"]["CLIENT_CLASS"] ==
                     "django_redis.client.HerdClient")
         _is_shard = (_params["OPTIONS"]["CLIENT_CLASS"] ==
-                    "django_redis.client.ShardClient")
+                     "django_redis.client.ShardClient")
 
         # Not supported for shard client.
         if _is_shard:
@@ -460,7 +466,7 @@ class DjangoRedisCacheTests(TestCase):
         cache = get_cache("default")
         _params = cache._params
         _is_shard = (_params["OPTIONS"]["CLIENT_CLASS"] ==
-                    "django_redis.client.ShardClient")
+                     "django_redis.client.ShardClient")
 
         if _is_shard:
             return
@@ -496,6 +502,7 @@ class DjangoRedisCacheTests(TestCase):
 
 import django_redis.cache
 
+
 class DjangoOmitExceptionsTests(TestCase):
     def setUp(self):
         self._orig_setting = django_redis.cache.DJANGO_REDIS_IGNORE_EXCEPTIONS
@@ -518,7 +525,6 @@ try:
     from django.contrib.sessions.tests import SessionTestsMixin
 except ImportError:
     class SessionTestsMixin(object): pass
-
 
 
 class SessionTests(SessionTestsMixin, TestCase):


### PR DESCRIPTION
lol

I kept getting a warning regarding line 25 in django-redis/utils.py; django is deprecating the importlib module in their utilities. After loading everything up, the code causing the warning was already removed. My local copy was outdated.

Regardless, I didn't discover this until running tests and changing a few import lines that will conflict with 1.9 in the future.

Decided to commit anyway; my waste of time doesn't need to be a waste for you.